### PR TITLE
Fix highlight color on search (for black/sepia)

### DIFF
--- a/plugins/highlighter/main.js
+++ b/plugins/highlighter/main.js
@@ -117,7 +117,7 @@ define(['readium_js_plugins', 'text!./styles.css'], function (Plugins, css) {
     div.style.top = top + 'px';
     div.style.width = width + 'px';
     div.style.height = height + 'px';
-    div.style.backgroundColor = config.highlightColor;
+    div.style.setProperty('background-color', config.highlightColor, 'important');
     zone.append(div);
 
     return div;


### PR DESCRIPTION
    - When the reader background is set to sepia or black, the search
      highlight color is the same than the background, so the searched text
      is hidden instead of highlight.
      --> Force the highlight color to remain the same with 'important'
      priority